### PR TITLE
Sds 312/build diffing

### DIFF
--- a/scripts/exportFromSketch.js
+++ b/scripts/exportFromSketch.js
@@ -20,6 +20,9 @@ const PLATFORM = process.argv[4];
 const FORMAT = process.argv[5];
 
 /**
+ * Uses sketchtoolUtils to export `fileNames` sketch files
+ * to specified format and platform
+ *
  * @param {Array} fileNames - list of modified files from SRC_DIR
  */
 const exportFiles = fileNames => {

--- a/scripts/exportFromSketch.js
+++ b/scripts/exportFromSketch.js
@@ -20,10 +20,10 @@ const PLATFORM = process.argv[4];
 const FORMAT = process.argv[5];
 
 /**
- * @param {Array} modifiedFiles - list of modified files from SRC_DIR
+ * @param {Array} fileNames - list of modified files from SRC_DIR
  */
-const exportFiles = modifiedFiles => {
-	modifiedFiles
+const exportFiles = fileNames => {
+	fileNames
 		.forEach(file => {
 			exportArtboards(
 				`${SRC_DIR}${file}`,
@@ -34,25 +34,50 @@ const exportFiles = modifiedFiles => {
 		});
 };
 
+/**
+ * @param {String} stdout - produced by git command
+ * @returns {Array} - array of file names
+ */
+const diffToArray = stdout => stdout
+	.split('\n')        // array from stdout lines
+	.filter(f => f)     // filter empty strings
+	.map(f => f         // take only the file name and extension
+		.split(/\//)
+		.pop()
+	);
+
 // only build files that have changed
+//
+// we can't assume that the sketch files are committed before
+// running the build, so we must `diff` against master _and_
+// `status` the sketch source dir
 exec(
 	`git diff master --name-only ${SRC_DIR}`,
-	(error, result) => {
+	(error, committedFiles) => {
 			if (error !== null) throw new Error(`exec error: ${error}`);
 
-			modifiedFiles = result
-				.split('\n')        // array from stdout lines
-				.filter(f => f)     // filter empty strings
-				.map(f => f         // take only the file name and extension
-					.split(/\//)
-					.pop()
-				);
+			exec(
+				`git status --porcelain ${SRC_DIR}`,
+				(error, localModFiles) => {
+						if (error !== null) throw new Error(`exec error: ${error}`);
 
-			if (modifiedFiles.length) {
-				console.info(`Exporting ${modifiedFiles} as ${FORMAT} for ${PLATFORM}`);
-				exportFiles(modifiedFiles);
-			} else {
-				console.info('No sketch changes found, halting build');
-			}
+					const filesToExport = Array.from(
+						new Set([
+							...diffToArray(committedFiles),
+							...diffToArray(localModFiles)
+						])
+					);
+
+					if (filesToExport.length) {
+						console.info(`Exporting ${filesToExport} as ${FORMAT} for ${PLATFORM}`);
+						exportFiles(filesToExport);
+
+					} else {
+						console.info('No sketch changes found, halting build');
+					}
+
+				}
+			);
+
 	}
 );

--- a/scripts/exportFromSketch.js
+++ b/scripts/exportFromSketch.js
@@ -48,6 +48,11 @@ exec(
 					.pop()
 				);
 
-			exportFiles(modifiedFiles);
+			if (modifiedFiles.length) {
+				console.info(`Exporting ${modifiedFiles} as ${FORMAT} for ${PLATFORM}`);
+				exportFiles(modifiedFiles);
+			} else {
+				console.info('No sketch changes found, halting build');
+			}
 	}
 );

--- a/scripts/exportFromSketch.js
+++ b/scripts/exportFromSketch.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const exportArtboards = require('./util/sketchtoolUtils').exportArtboardsFromFile;
+const exec = require('child_process').exec;
 
 /**
  * Generates icon distributions from sketch files in `src/sketch`
@@ -18,12 +19,35 @@ const DEST_DIR = process.argv[3];
 const PLATFORM = process.argv[4];
 const FORMAT = process.argv[5];
 
-fs.readdirSync(SRC_DIR)
-	.forEach(file => {
-		exportArtboards(
-			`${SRC_DIR}${file}`,
-			DEST_DIR,
-			PLATFORM,
-			FORMAT
-		);
-	});
+/**
+ * @param {Array} modifiedFiles - list of modified files from SRC_DIR
+ */
+const exportFiles = modifiedFiles => {
+	modifiedFiles
+		.forEach(file => {
+			exportArtboards(
+				`${SRC_DIR}${file}`,
+				DEST_DIR,
+				PLATFORM,
+				FORMAT
+			);
+		});
+};
+
+// only build files that have changed
+exec(
+	`git diff master --name-only ${SRC_DIR}`,
+	(error, result) => {
+			if (error !== null) throw new Error(`exec error: ${error}`);
+
+			modifiedFiles = result
+				.split('\n')        // array from stdout lines
+				.filter(f => f)     // filter empty strings
+				.map(f => f         // take only the file name and extension
+					.split(/\//)
+					.pop()
+				);
+
+			exportFiles(modifiedFiles);
+	}
+);

--- a/scripts/exportFromSketch.js
+++ b/scripts/exportFromSketch.js
@@ -76,7 +76,7 @@ exec(
 						exportFiles(filesToExport);
 
 					} else {
-						console.info('No sketch changes found, halting build');
+						console.info('No sketch changes found, skipping build');
 					}
 
 				}


### PR DESCRIPTION
The `exportFromSketch.js` build script will now build only modified or new `.sketch` files instead of the entire directory every time. This will make our PRs a bit easier to understand going forward.