### PR TITLE
Simplify build steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 .DS_Store
 src/**/.DS_Store
+*.log
 
 npm-debug.log
 

--- a/README.md
+++ b/README.md
@@ -132,3 +132,17 @@ task                      | description
 `yarn run build`          | builds all icon distributions to `dist/`; builds docs to `doc/build`
 `yarn run publish-docs`   | builds and publishes documentation to github pages
 
+#### Sketch export configuration
+The script that exports artboards from sketch files, `scripts/exportFromSketch`, reads from a configuration file, `exportConfig.json`.
+The config file for this script follows this format:
+
+```
+{
+	"name": <name of export set for reference>,
+	"options": {
+		"destination": <destination for exported files>,
+		"platform": <name of platform "page" in sketch file>,
+		"format": <export file format>
+	}
+}
+```

--- a/exportConfig.json
+++ b/exportConfig.json
@@ -20,7 +20,7 @@
 		{
 			"name": "Android SVG",
 			"options": {
-				"destination": "./dist/svg/android",
+				"destination": "./dist/android/svg",
 				"platform": "android",
 				"format": "svg"
 			}

--- a/exportConfig.json
+++ b/exportConfig.json
@@ -20,7 +20,7 @@
 		{
 			"name": "Android SVG",
 			"options": {
-				"destination": "./dist/android/svg",
+				"destination": "./dist/svg/android",
 				"platform": "android",
 				"format": "svg"
 			}

--- a/exportConfig.json
+++ b/exportConfig.json
@@ -1,0 +1,29 @@
+{
+	"source": ["./src/sketch"],
+	"distributions": [
+		{
+			"name": "raw SVG icons",
+			"options": {
+				"destination": "./dist/svg",
+				"platform": "web",
+				"format": "svg"
+			}
+		},
+		{
+			"name": "PDF icons",
+			"options": {
+				"destination": "./dist/pdf",
+				"platform": "ios",
+				"format": "pdf"
+			}
+		},
+		{
+			"name": "Android SVG",
+			"options": {
+				"destination": "./dist/svg/android",
+				"platform": "android",
+				"format": "svg"
+			}
+		}
+	]
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "svgSprite": "grunt svgstore",
   "test": "echo no tests found",
   "docs": "grunt preprocess",
-  "build": "yarn run jsConstants && yarn run exportFromSketch && run run optimize && yarn run svgSprite",
+  "build": "yarn run jsConstants && yarn run exportFromSketch && yarn run optimize && yarn run svgSprite",
   "publish-docs": "yarn run build && grunt gh-pages"
  },
  "repository": {

--- a/package.json
+++ b/package.json
@@ -7,16 +7,13 @@
   "dist": "dist"
  },
  "scripts": {
-  "dist:svg": "node scripts/exportFromSketch.js src/sketch/ dist/svg/ web svg",
-  "dist:pdf": "node scripts/exportFromSketch.js src/sketch/ dist/pdf/ ios pdf",
-  "dist:js": "node scripts/generateConstants.js src/sketch dist/js/",
-  "dist:androidSvg": "node scripts/exportFromSketch.js src/sketch/ dist/svg/android/ android svg",
-  "dist:optimized": "grunt minifySvg --platform=web",
-  "dist:optimizedAndroid": "grunt minifySvg --platform=android",
-  "dist:sprite": "grunt svgstore",
+  "jsConstants": "node scripts/generateConstants.js src/sketch dist/js/",
+  "exportFromSketch": "node scripts/exportFromSketch.js exportConfig.json",
+  "optimize": "grunt minifySvg --platform=web && grunt minifySvg --platform=android",
+  "svgSprite": "grunt svgstore",
   "test": "echo no tests found",
   "docs": "grunt preprocess",
-  "build": "yarn run dist:svg && yarn run dist:androidSvg && yarn run dist:pdf && yarn run dist:optimized && yarn run dist:optimizedAndroid && yarn run dist:js && yarn run dist:sprite && yarn run docs",
+  "build": "yarn run jsConstants && yarn run exportFromSketch && run run optimize && yarn run svgSprite"
   "publish-docs": "yarn run build && grunt gh-pages"
  },
  "repository": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "svgSprite": "grunt svgstore",
   "test": "echo no tests found",
   "docs": "grunt preprocess",
-  "build": "yarn run jsConstants && yarn run exportFromSketch && run run optimize && yarn run svgSprite"
+  "build": "yarn run jsConstants && yarn run exportFromSketch && run run optimize && yarn run svgSprite",
   "publish-docs": "yarn run build && grunt gh-pages"
  },
  "repository": {

--- a/scripts/exportFromSketch.js
+++ b/scripts/exportFromSketch.js
@@ -76,11 +76,6 @@ exec(
 
 		const filesToExport = diffToArray(result);
 
-		if (!filesToExport.length) {
-			console.info('\nNo sketch changes found, skipping build\n');
-			return;
-		}
-
 		if (!config.distributions.length) {
 			console.info('\nNo distributions found in config.json\n');
 			return;

--- a/scripts/exportFromSketch.js
+++ b/scripts/exportFromSketch.js
@@ -89,11 +89,13 @@ exec(
 		// run export for each distribution
 		config.distributions.forEach(dist => {
 			const {
+				name,
 				destination,
 				platform,
 				format,
 			} = dist.options;
 
+			console.info(`\n${name}:`);
 			console.info(`Queuing export of ${format} files for ${platform}...`);
 
 			// run export on all sketch files with current dist config

--- a/scripts/exportFromSketch.js
+++ b/scripts/exportFromSketch.js
@@ -22,6 +22,9 @@ const exec = require('child_process').exec;
  * `node exportFromSketch <exportConfig.json>`
  */
 
+const config = JSON.parse(fs.readFileSync(process.argv[2]));
+const SRC_DIR = config.source;
+
 //
 // Because we `diff` against `master` to select which files to export,
 // bail out if `src/sketch/` is in dirty state.
@@ -45,9 +48,6 @@ exec(
 			}
 	}
 );
-
-const config = JSON.parse(fs.readFileSync(process.argv[2]));
-const SRC_DIR = config.source;
 
 /**
  * Uses sketchtoolUtils to export `fileNames` sketch files

--- a/scripts/exportFromSketch.js
+++ b/scripts/exportFromSketch.js
@@ -89,13 +89,12 @@ exec(
 		// run export for each distribution
 		config.distributions.forEach(dist => {
 			const {
-				name,
 				destination,
 				platform,
 				format,
 			} = dist.options;
 
-			console.info(`\n${name}:`);
+			console.info(`\n${dist.name}:`);
 			console.info(`Queuing export of ${format} files for ${platform}...`);
 
 			// run export on all sketch files with current dist config

--- a/scripts/exportFromSketch.js
+++ b/scripts/exportFromSketch.js
@@ -94,7 +94,7 @@ exec(
 				format,
 			} = dist.options;
 
-			console.info(`Preparing to export ${format} files for ${platform}...`);
+			console.info(`Queuing export of ${format} files for ${platform}...`);
 
 			// run export on all sketch files with current dist config
 			filesToExport.forEach(file => {


### PR DESCRIPTION
Simplifies exporting artboards from sketch so the script can be called using a single `yarn` command. This should help clarify the order in which the build steps are executed (some build steps require build artifacts from previous steps).